### PR TITLE
Hinzufügen eines einfachen, globalen Chat

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -13,11 +13,11 @@
 	<properties>
 		<java.version>21</java.version>
 	</properties>
-	
+
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.4</version>
+		<version>3.5.14</version>
 	</parent>
 
     <dependencies>

--- a/backend/src/main/java/ch/bztf/m165_m426/DatabaseInitializer.java
+++ b/backend/src/main/java/ch/bztf/m165_m426/DatabaseInitializer.java
@@ -1,35 +1,53 @@
 package ch.bztf.m165_m426;
 
+import java.time.LocalDateTime;
+
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import ch.bztf.m165_m426.entities.GlobalMessage;
 import ch.bztf.m165_m426.entities.Users;
+import ch.bztf.m165_m426.repositories.GlobalMessageRepository;
 import ch.bztf.m165_m426.repositories.UsersRepository;
 
 @Configuration
 public class DatabaseInitializer {
 
     private final UsersRepository userRepo;
+    private final GlobalMessageRepository messageRepo;
 
-    public DatabaseInitializer(UsersRepository userRepo) {
+    public DatabaseInitializer(UsersRepository userRepo, GlobalMessageRepository messageRepo) {
         this.userRepo = userRepo;
+        this.messageRepo = messageRepo;
     }
 
     @Bean
     CommandLineRunner initDatabase() {
-        return runCommand -> addTestUsers();
+        return runCommands -> addTestUsers();
     }
 
     private void addTestUsers() {
-        // SHA256 of the string "password"
-        final String passwordHash = "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8";
+        LocalDateTime now = LocalDateTime.now();
 
-        userRepo.save(Users.create("Max Mustermann", "max.mustermann@example.org", passwordHash));
+        // Hash of the string "password"
+        final String pwdHash = "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8";
 
-        userRepo.save(Users.create("Esteban Venturello", "eve@bztf.ch", passwordHash));
-        userRepo.save(Users.create("Flavio Köppel", "fko@bztf.ch", passwordHash));
-        userRepo.save(Users.create("Tobias Nussbaumer", "tnu@bztf.ch", passwordHash));
-        userRepo.save(Users.create("Noah Bösch", "nbo@bztf.ch", passwordHash));
+        Users muster = userRepo.save(Users.create("Max Mustermann", "max.mustermann@example.org", pwdHash));
+        messageRepo.save(GlobalMessage.createMessage(muster, now, "TestNachricht"));
+
+        Users esteban = userRepo.save(Users.create("Esteban Venturello", "eve@bztf.ch", pwdHash));
+        Users flavio = userRepo.save(Users.create("Flavio Köppel", "fko@bztf.ch", pwdHash));
+        Users tobias = userRepo.save(Users.create("Tobias Nussbaumer", "tnu@bztf.ch", pwdHash));
+        Users noah = userRepo.save(Users.create("Noah Bösch", "nbo@bztf.ch", pwdHash));
+
+        GlobalMessage estebMessage = messageRepo.save(GlobalMessage.createMessage(esteban, now.plusSeconds(15), "Hallo!"));
+
+        messageRepo.save(GlobalMessage.createMessage(flavio, now.plusSeconds(30), "Wilkommen"));
+        messageRepo.save(GlobalMessage.createMessage(tobias, now.plusSeconds(45), "sup"));
+
+        GlobalMessage noahReply = messageRepo.save(GlobalMessage.createReply(noah, now.plusSeconds(60), "Hallo, wie läufts?", estebMessage));
+        messageRepo.save(GlobalMessage.createReply(esteban, now.plusSeconds(75), "Ganz okay", noahReply));
+
     }
 }

--- a/backend/src/main/java/ch/bztf/m165_m426/DatabaseInitializer.java
+++ b/backend/src/main/java/ch/bztf/m165_m426/DatabaseInitializer.java
@@ -34,20 +34,20 @@ public class DatabaseInitializer {
         final String pwdHash = "5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8";
 
         Users muster = userRepo.save(Users.create("Max Mustermann", "max.mustermann@example.org", pwdHash));
-        messageRepo.save(GlobalMessage.createMessage(muster, now, "TestNachricht"));
+        messageRepo.save(GlobalMessage.create(muster, now, "TestNachricht", null));
 
         Users esteban = userRepo.save(Users.create("Esteban Venturello", "eve@bztf.ch", pwdHash));
         Users flavio = userRepo.save(Users.create("Flavio Köppel", "fko@bztf.ch", pwdHash));
         Users tobias = userRepo.save(Users.create("Tobias Nussbaumer", "tnu@bztf.ch", pwdHash));
         Users noah = userRepo.save(Users.create("Noah Bösch", "nbo@bztf.ch", pwdHash));
 
-        GlobalMessage estebMessage = messageRepo.save(GlobalMessage.createMessage(esteban, now.plusSeconds(15), "Hallo!"));
+        GlobalMessage estebMessage = messageRepo.save(GlobalMessage.create(esteban, now.plusSeconds(15), "Hallo!", null));
 
-        messageRepo.save(GlobalMessage.createMessage(flavio, now.plusSeconds(30), "Wilkommen"));
-        messageRepo.save(GlobalMessage.createMessage(tobias, now.plusSeconds(45), "sup"));
+        messageRepo.save(GlobalMessage.create(flavio, now.plusSeconds(30), "Wilkommen", null));
+        messageRepo.save(GlobalMessage.create(tobias, now.plusSeconds(45), "sup", null));
 
-        GlobalMessage noahReply = messageRepo.save(GlobalMessage.createReply(noah, now.plusSeconds(60), "Hallo, wie läufts?", estebMessage));
-        messageRepo.save(GlobalMessage.createReply(esteban, now.plusSeconds(75), "Ganz okay", noahReply));
+        GlobalMessage noahReply = messageRepo.save(GlobalMessage.create(noah, now.plusSeconds(60), "Hallo, wie läufts?", estebMessage));
+        messageRepo.save(GlobalMessage.create(esteban, now.plusSeconds(75), "Ganz okay", noahReply));
 
     }
 }

--- a/backend/src/main/java/ch/bztf/m165_m426/api/MessageApi.java
+++ b/backend/src/main/java/ch/bztf/m165_m426/api/MessageApi.java
@@ -27,8 +27,7 @@ public class MessageApi {
 
     @GetMapping("/messages")
     public List<MessageApiObject> getAllMessages() {
-        return messageRepo.findAll()
-                .stream()
+        return messageRepo.findAll().stream()
                 .map(message -> message.toMessageApiObject())
                 .toList();
     }
@@ -37,6 +36,11 @@ public class MessageApi {
     public MessageApiObject getMessage(@PathVariable Long id) {
         return messageRepo.findById(id).orElseThrow()
                 .toMessageApiObject();
+    }
+
+    @GetMapping("/messages/{id}/replies")
+    public List<MessageApiObject> getMessageReplies(@PathVariable Long id) {
+        return messageRepo.getReplyTree(id);
     }
 
     @PostMapping("/messages")

--- a/backend/src/main/java/ch/bztf/m165_m426/api/MessageApi.java
+++ b/backend/src/main/java/ch/bztf/m165_m426/api/MessageApi.java
@@ -6,6 +6,7 @@ import java.util.NoSuchElementException;
 import org.springframework.web.bind.annotation.*;
 
 import ch.bztf.m165_m426.entities.GlobalMessage;
+import ch.bztf.m165_m426.entities.GlobalMessage.MessageApiObject;
 import ch.bztf.m165_m426.repositories.GlobalMessageRepository;
 
 @RestController
@@ -19,13 +20,17 @@ public class MessageApi {
     }
 
     @GetMapping("/messages")
-    public List<GlobalMessage> getAllMessages() {
-        return messageRepo.findAll();
+    public List<MessageApiObject> getAllMessages() {
+        return messageRepo.findAll()
+                .stream()
+                .map(message -> message.toMessageApiObject())
+                .toList();
     }
 
     @GetMapping("/messages/{id}")
-    public GlobalMessage getMessage(@PathVariable Long id) {
-        return messageRepo.findById(id).orElseThrow();
+    public MessageApiObject getMessage(@PathVariable Long id) {
+        return messageRepo.findById(id).orElseThrow()
+                .toMessageApiObject();
     }
 
     @PostMapping("/messages")

--- a/backend/src/main/java/ch/bztf/m165_m426/api/MessageApi.java
+++ b/backend/src/main/java/ch/bztf/m165_m426/api/MessageApi.java
@@ -1,0 +1,51 @@
+package ch.bztf.m165_m426.api;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import org.springframework.web.bind.annotation.*;
+
+import ch.bztf.m165_m426.entities.GlobalMessage;
+import ch.bztf.m165_m426.repositories.GlobalMessageRepository;
+
+@RestController
+@CrossOrigin(origins = "http://localhost:4200")
+public class MessageApi {
+
+    private final GlobalMessageRepository messageRepo;
+
+    public MessageApi(GlobalMessageRepository messageRepo) {
+        this.messageRepo = messageRepo;
+    }
+
+    @GetMapping("/messages")
+    public List<GlobalMessage> getAllMessages() {
+        return messageRepo.findAll();
+    }
+
+    @GetMapping("/messages/{id}")
+    public GlobalMessage getMessage(@PathVariable Long id) {
+        return messageRepo.findById(id).orElseThrow();
+    }
+
+    @PostMapping("/messages")
+    public GlobalMessage sendMessage(
+            @RequestBody GlobalMessage message) {
+        return messageRepo.save(message);
+    }
+
+    @PostMapping("/messages/{id}/reply")
+    public GlobalMessage replyToMessage(@PathVariable Long id, @RequestBody GlobalMessage reply) {
+        messageRepo.findById(id).orElseThrow();
+        return messageRepo.save(reply);
+    }
+
+    @DeleteMapping("/messages/{id}")
+    public void deleteMessage(@PathVariable Long id) {
+        if (!messageRepo.existsById(id)) {
+            throw new NoSuchElementException("Message with id " + id + " not found");
+        }
+
+        messageRepo.deleteById(id);
+    }
+}

--- a/backend/src/main/java/ch/bztf/m165_m426/api/MessageApi.java
+++ b/backend/src/main/java/ch/bztf/m165_m426/api/MessageApi.java
@@ -6,17 +6,23 @@ import java.util.NoSuchElementException;
 import org.springframework.web.bind.annotation.*;
 
 import ch.bztf.m165_m426.entities.GlobalMessage;
+import ch.bztf.m165_m426.entities.GlobalMessage.CreateMessageRequest;
+import ch.bztf.m165_m426.entities.GlobalMessage.CreateReplyRequest;
 import ch.bztf.m165_m426.entities.GlobalMessage.MessageApiObject;
+import ch.bztf.m165_m426.entities.Users;
 import ch.bztf.m165_m426.repositories.GlobalMessageRepository;
+import ch.bztf.m165_m426.repositories.UsersRepository;
 
 @RestController
 @CrossOrigin(origins = "http://localhost:4200")
 public class MessageApi {
 
     private final GlobalMessageRepository messageRepo;
+    private final UsersRepository userRepo;
 
-    public MessageApi(GlobalMessageRepository messageRepo) {
+    public MessageApi(GlobalMessageRepository messageRepo, UsersRepository userRepo) {
         this.messageRepo = messageRepo;
+        this.userRepo = userRepo;
     }
 
     @GetMapping("/messages")
@@ -34,15 +40,23 @@ public class MessageApi {
     }
 
     @PostMapping("/messages")
-    public GlobalMessage sendMessage(
-            @RequestBody GlobalMessage message) {
-        return messageRepo.save(message);
+    public MessageApiObject sendMessage(@RequestBody CreateMessageRequest message) {
+        // getReferenceById skips the inmediate repository call
+        Users user = userRepo.getReferenceById(message.createdById());
+
+        return messageRepo.save(
+                GlobalMessage.createMessage(user, message.message()))
+                .toMessageApiObject();
     }
 
-    @PostMapping("/messages/{id}/reply")
-    public GlobalMessage replyToMessage(@PathVariable Long id, @RequestBody GlobalMessage reply) {
-        messageRepo.findById(id).orElseThrow();
-        return messageRepo.save(reply);
+    @PostMapping("/messages/{id}/replies")
+    public MessageApiObject replyToMessage(@RequestBody CreateReplyRequest reply) {
+        Users user = userRepo.getReferenceById(reply.createdById());
+        GlobalMessage parentMessage = messageRepo.getReferenceById(reply.parentMessageId());
+
+        return messageRepo.save(
+                GlobalMessage.createReply(user, reply.message(), parentMessage))
+                .toMessageApiObject();
     }
 
     @DeleteMapping("/messages/{id}")

--- a/backend/src/main/java/ch/bztf/m165_m426/api/MessageApi.java
+++ b/backend/src/main/java/ch/bztf/m165_m426/api/MessageApi.java
@@ -65,10 +65,9 @@ public class MessageApi {
 
     @DeleteMapping("/messages/{id}")
     public void deleteMessage(@PathVariable Long id) {
-        if (!messageRepo.existsById(id)) {
-            throw new NoSuchElementException("Message with id " + id + " not found");
-        }
+        GlobalMessage message = messageRepo.findById(id).orElseThrow(() -> new NoSuchElementException("Message with id " + id + " not found"));
 
-        messageRepo.deleteById(id);
+        message.deleteMessage();
+        messageRepo.save(message);
     }
 }

--- a/backend/src/main/java/ch/bztf/m165_m426/api/MessageApi.java
+++ b/backend/src/main/java/ch/bztf/m165_m426/api/MessageApi.java
@@ -7,7 +7,6 @@ import org.springframework.web.bind.annotation.*;
 
 import ch.bztf.m165_m426.entities.GlobalMessage;
 import ch.bztf.m165_m426.entities.GlobalMessage.CreateMessageRequest;
-import ch.bztf.m165_m426.entities.GlobalMessage.CreateReplyRequest;
 import ch.bztf.m165_m426.entities.GlobalMessage.MessageApiObject;
 import ch.bztf.m165_m426.entities.Users;
 import ch.bztf.m165_m426.repositories.GlobalMessageRepository;
@@ -54,9 +53,9 @@ public class MessageApi {
     }
 
     @PostMapping("/messages/{id}/replies")
-    public MessageApiObject replyToMessage(@RequestBody CreateReplyRequest reply) {
+    public MessageApiObject replyToMessage(@PathVariable Long id, @RequestBody CreateMessageRequest reply) {
         Users user = userRepo.getReferenceById(reply.createdById());
-        GlobalMessage parentMessage = messageRepo.getReferenceById(reply.parentMessageId());
+        GlobalMessage parentMessage = messageRepo.getReferenceById(id);
 
         return messageRepo.save(
                 GlobalMessage.createReply(user, reply.message(), parentMessage))

--- a/backend/src/main/java/ch/bztf/m165_m426/api/MessageApi.java
+++ b/backend/src/main/java/ch/bztf/m165_m426/api/MessageApi.java
@@ -3,6 +3,7 @@ package ch.bztf.m165_m426.api;
 import java.util.List;
 import java.util.NoSuchElementException;
 
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 import ch.bztf.m165_m426.entities.GlobalMessage;
@@ -33,7 +34,8 @@ public class MessageApi {
 
     @GetMapping("/messages/{id}")
     public MessageApiObject getMessage(@PathVariable Long id) {
-        return messageRepo.findById(id).orElseThrow()
+        return messageRepo.findById(id)
+                .orElseThrow(() -> messageNotFoundException(id))
                 .toMessageApiObject();
     }
 
@@ -62,11 +64,15 @@ public class MessageApi {
                 .toMessageApiObject();
     }
 
+    @Transactional
     @DeleteMapping("/messages/{id}")
     public void deleteMessage(@PathVariable Long id) {
-        GlobalMessage message = messageRepo.findById(id).orElseThrow(() -> new NoSuchElementException("Message with id " + id + " not found"));
+        messageRepo.findById(id)
+                .orElseThrow(() -> messageNotFoundException(id))
+                .deleteMessage();
+    }
 
-        message.deleteMessage();
-        messageRepo.save(message);
+    private NoSuchElementException messageNotFoundException(Long id) {
+        return new NoSuchElementException("Message with id " + id + " not found");
     }
 }

--- a/backend/src/main/java/ch/bztf/m165_m426/entities/GlobalMessage.java
+++ b/backend/src/main/java/ch/bztf/m165_m426/entities/GlobalMessage.java
@@ -44,12 +44,16 @@ public class GlobalMessage {
         this.parentMessage = parentMessage;
     }
 
-    public static GlobalMessage createMessage(Users createdBy, LocalDateTime createdAt, String message) {
-        return new GlobalMessage(createdBy, createdAt, message, null);
+    public static GlobalMessage create(Users createdBy, LocalDateTime createdAt, String message, GlobalMessage parentMessage) {
+        return new GlobalMessage(createdBy, createdAt, message, parentMessage);
     }
 
-    public static GlobalMessage createReply(Users createdBy, LocalDateTime createdAt, String message, GlobalMessage parentMessage) {
-        return new GlobalMessage(createdBy, createdAt, message, parentMessage);
+    public static GlobalMessage createMessage(Users createdBy, String message) {
+        return create(createdBy, LocalDateTime.now(), message, null);
+    }
+
+    public static GlobalMessage createReply(Users createdBy, String message, GlobalMessage parentMessage) {
+        return create(createdBy, LocalDateTime.now(), message, parentMessage);
     }
 
     public Long getId() {

--- a/backend/src/main/java/ch/bztf/m165_m426/entities/GlobalMessage.java
+++ b/backend/src/main/java/ch/bztf/m165_m426/entities/GlobalMessage.java
@@ -83,4 +83,20 @@ public class GlobalMessage {
     public GlobalMessage getParentMessage() {
         return parentMessage;
     }
+
+    // DTO for API, so that the JSON does not include the entire User object and parent messages
+    public record MessageApiObject(
+            Long id,
+            Long createdById, String createdByName,
+            LocalDateTime createdAt, String message, boolean isDeleted,
+            Long parentMessageId) {
+    }
+
+    public MessageApiObject toMessageApiObject() {
+        return new MessageApiObject(
+                id,
+                createdBy.getId(), createdBy.getName(),
+                createdAt, message, isDeleted,
+                parentMessage != null ? parentMessage.getId() : null);
+    }
 }

--- a/backend/src/main/java/ch/bztf/m165_m426/entities/GlobalMessage.java
+++ b/backend/src/main/java/ch/bztf/m165_m426/entities/GlobalMessage.java
@@ -99,4 +99,10 @@ public class GlobalMessage {
                 createdAt, message, isDeleted,
                 parentMessage != null ? parentMessage.getId() : null);
     }
+
+    public record CreateMessageRequest(Long createdById, String message) {
+    }
+
+    public record CreateReplyRequest(Long createdById, String message, Long parentMessageId) {
+    }
 }

--- a/backend/src/main/java/ch/bztf/m165_m426/entities/GlobalMessage.java
+++ b/backend/src/main/java/ch/bztf/m165_m426/entities/GlobalMessage.java
@@ -1,0 +1,82 @@
+package ch.bztf.m165_m426.entities;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.Immutable;
+
+import jakarta.persistence.*;
+
+@Entity
+public class GlobalMessage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    private Long id;
+
+    // ManyToOne is FK to Users
+    @Immutable
+    @ManyToOne(optional = false)
+    private Users createdBy;
+
+    @Immutable
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Immutable
+    @Column(nullable = false)
+    private String message;
+
+    @Column(nullable = false)
+    private boolean isDeleted;
+
+    @Immutable
+    @ManyToOne(optional = true)
+    private GlobalMessage parentMessage;
+
+    protected GlobalMessage() {
+    }
+
+    private GlobalMessage(Users createdBy, LocalDateTime createdAt, String message, GlobalMessage parentMessage) {
+        this.createdBy = createdBy;
+        this.createdAt = createdAt;
+        this.message = message;
+        this.isDeleted = false;
+        this.parentMessage = parentMessage;
+    }
+
+    public static GlobalMessage createMessage(Users createdBy, LocalDateTime createdAt, String message) {
+        return new GlobalMessage(createdBy, createdAt, message, null);
+    }
+
+    public static GlobalMessage createReply(Users createdBy, LocalDateTime createdAt, String message, GlobalMessage parentMessage) {
+        return new GlobalMessage(createdBy, createdAt, message, parentMessage);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Users getCreatedBy() {
+        return createdBy;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public boolean isDeleted() {
+        return isDeleted;
+    }
+
+    public void deleteMessage() {
+        this.isDeleted = true;
+    }
+
+    public GlobalMessage getParentMessage() {
+        return parentMessage;
+    }
+}

--- a/backend/src/main/java/ch/bztf/m165_m426/entities/GlobalMessage.java
+++ b/backend/src/main/java/ch/bztf/m165_m426/entities/GlobalMessage.java
@@ -102,7 +102,4 @@ public class GlobalMessage {
 
     public record CreateMessageRequest(Long createdById, String message) {
     }
-
-    public record CreateReplyRequest(Long createdById, String message, Long parentMessageId) {
-    }
 }

--- a/backend/src/main/java/ch/bztf/m165_m426/repositories/GlobalMessageRepository.java
+++ b/backend/src/main/java/ch/bztf/m165_m426/repositories/GlobalMessageRepository.java
@@ -1,9 +1,25 @@
 package ch.bztf.m165_m426.repositories;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import ch.bztf.m165_m426.entities.GlobalMessage;
+import ch.bztf.m165_m426.entities.GlobalMessage.MessageApiObject;
 
 public interface GlobalMessageRepository extends JpaRepository<GlobalMessage, Long> {
 
+    List<GlobalMessage> findByParentMessageId(Long parentMessageId);
+
+    default List<MessageApiObject> getReplyTree(Long id) {
+        List<MessageApiObject> replyTree = new ArrayList<>();
+
+        for (GlobalMessage reply : findByParentMessageId(id)) {
+            replyTree.add(reply.toMessageApiObject()); // Add current reply
+            replyTree.addAll(getReplyTree(reply.getId())); // Add all sub-replies of the current reply
+        }
+
+        return replyTree;
+    }
 }

--- a/backend/src/main/java/ch/bztf/m165_m426/repositories/GlobalMessageRepository.java
+++ b/backend/src/main/java/ch/bztf/m165_m426/repositories/GlobalMessageRepository.java
@@ -1,0 +1,9 @@
+package ch.bztf.m165_m426.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import ch.bztf.m165_m426.entities.GlobalMessage;
+
+public interface GlobalMessageRepository extends JpaRepository<GlobalMessage, Long> {
+
+}


### PR DESCRIPTION
Erstellt das Backend für globale Nachrichten. Beinhaltet ein GlobalMessages-Objekt, deren Datenbank und die dazugehörende verbundene JPA-Repository, und eine API unter /messages