### PR TITLE
Adjusting backend stuff

### DIFF
--- a/backend/.mvn/jvm.config
+++ b/backend/.mvn/jvm.config
@@ -1,1 +1,0 @@
---enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -10,15 +10,15 @@
     <name>m165-m426</name>
     <description>Sozialnetzwerk für die Schule</description>
 
-	<properties>
-		<java.version>21</java.version>
-	</properties>
-	
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.4</version>
-	</parent>
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.5.14</version>
+    </parent>
 
     <dependencies>
 
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.10</version>
+            <version>42.7.11</version>
             <scope>runtime</scope>
         </dependency>
 
@@ -92,6 +92,7 @@
             </plugin>
 
             <!-- Fixes various warnings related to Mockito using dynamic loading and self-attaching to the VM -->
+            <!-- Only applicable to tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
- Removes the test-specific `application.properties` file so it defaults to the already configured file in src.
- Removes `--enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow` flags for compatibility with Java 21
- Upgrades dependencies